### PR TITLE
Fix LineFollower slew rate scaling

### DIFF
--- a/LineFollow.hpp
+++ b/LineFollow.hpp
@@ -38,8 +38,10 @@ public:
         vR = clamp(vR, -speed_limit_, speed_limit_);
 
         if (slew_rate_ > 0.0f) {
-            vL = clamp(vL, prev_vL_ - slew_rate_, prev_vL_ + slew_rate_);
-            vR = clamp(vR, prev_vR_ - slew_rate_, prev_vR_ + slew_rate_);
+            // slew_rate_ is specified in units per second, so scale by dt_
+            float max_delta = slew_rate_ * dt_;
+            vL = clamp(vL, prev_vL_ - max_delta, prev_vL_ + max_delta);
+            vR = clamp(vR, prev_vR_ - max_delta, prev_vR_ + max_delta);
         }
 
         prev_error_ = error;

--- a/tests/line_follower_slew_rate_test.cpp
+++ b/tests/line_follower_slew_rate_test.cpp
@@ -1,0 +1,22 @@
+#include "../LineFollow.hpp"
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+int main() {
+    LineFollower lf(1.0f, 0.0f, 0.0f, 0.0f, 0.1f); // dt=0.1s
+    lf.setSpeedLimit(1.0f);
+    lf.setSteerLimit(1.0f);
+    lf.setSlewRate(0.5f); // 0.5 units per second
+
+    auto cmd1 = lf.update(100, 0); // large error to saturate steer
+    assert(std::fabs(cmd1.first + 0.05f) < 1e-5f);
+    assert(std::fabs(cmd1.second - 0.05f) < 1e-5f);
+
+    auto cmd2 = lf.update(100, 0);
+    assert(std::fabs(cmd2.first + 0.10f) < 1e-5f);
+    assert(std::fabs(cmd2.second - 0.10f) < 1e-5f);
+
+    std::cout << "Slew rate test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- correct slew rate limiting in `LineFollower` to scale per control cycle
- add regression test for slew rate behavior

## Testing
- `g++ tests/line_follower_slew_rate_test.cpp -std=c++17 -o tests/line_follower_slew_rate_test`
- `./tests/line_follower_slew_rate_test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c841bf248322b69faa029c59d2db